### PR TITLE
Update links on how to find informations about us

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,9 +207,6 @@
 											<a href="http://trac.navit-project.org" target="_blank"><i class="fa fa-angle-double-right"></i>THE HISTORICAL BUG TRACKER</a>
 										</div>
 										<div class="cmosc-link">
-											<a href="https://sourceforge.net/projects/navit" target="_blank"><i class="fa fa-angle-double-right"></i>THE SOURCEFORGE PROJECT PAGE (for historical purposes, currently unmaintained, prefer the wiki or github)</a>
-										</div>
-										<div class="cmosc-link">
 											<a href="http://doxygen.navit-project.org/" target="_blank"><i class="fa fa-angle-double-right"></i>THE TECHNICAL DOCUMENTATION (generated via doxygen)</a>
 										</div>
 									</div>

--- a/index.html
+++ b/index.html
@@ -198,17 +198,21 @@
 											<a href="http://webchat.freenode.net/?channels=navit" target="_blank"><i class="fa fa-angle-double-right"></i>THE WEBCHAT</a>
 										</div>
 										<div class="cmosc-link">
-											<a href="http://trac.navit-project.org" target="_blank"><i class="fa fa-angle-double-right"></i>THE BUG TRACKER</a>
+											<a href="https://github.com/navit-gps/navit" target="_blank"><i class="fa fa-angle-double-right"></i>THE GITHUB PROJECT PAGE</a>
 										</div>
 										<div class="cmosc-link">
-											<a href="https://github.com/navit-gps/navit/ " target="_blank"><i class="fa fa-angle-double-right"></i>THE GITHUB PROJECT PAGE</a>
+											<a href="https://github.com/navit-gps/navit/issues" target="_blank"><i class="fa fa-angle-double-right"></i>THE GITHUB ISSUES TRACKER</a>
 										</div>
 										<div class="cmosc-link">
-											<a href=" https://sourceforge.net/projects/navit/" target="_blank"><i class="fa fa-angle-double-right"></i>THE SOURCEFORGE PROJECT PAGE</a>
+											<a href="http://trac.navit-project.org" target="_blank"><i class="fa fa-angle-double-right"></i>THE HISTORICAL BUG TRACKER</a>
 										</div>
-										
+										<div class="cmosc-link">
+											<a href="https://sourceforge.net/projects/navit" target="_blank"><i class="fa fa-angle-double-right"></i>THE SOURCEFORGE PROJECT PAGE (for historical purposes, currently unmaintained, prefer the wiki or github)</a>
+										</div>
+										<div class="cmosc-link">
+											<a href="http://doxygen.navit-project.org/" target="_blank"><i class="fa fa-angle-double-right"></i>THE TECHNICAL DOCUMENTATION (generated via doxygen)</a>
+										</div>
 									</div>
-									
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
* I don't believe referencing sourceforge as a reference is the best idea (maybe for historical ref but probably not more than that).
* Github issues are way more user-friendly than trac for contributors. I think it should be at least referenced as an alternative to trac.
* I think Doxygen should be referenced as it's our technical doc.